### PR TITLE
Added outputs option in the settings tab of the Compact-Server node

### DIFF
--- a/src/server-node.html
+++ b/src/server-node.html
@@ -150,6 +150,14 @@
           );
         }
       },
+      outputs: {
+        value: 0,
+        validate: function(v) {
+          return (
+            v === "" || (RED.validators.number(v) && v >= 0 && v <= 10)
+          );
+        }
+      },
       serverShutdownTimeout: {
         value: 100,
         validate: function(v) {
@@ -164,7 +172,6 @@
       }
     },
     inputs: 0,
-    outputs: 0,
     align: "right",
     icon: "icon.png",
     label: function() {
@@ -622,6 +629,10 @@
           <div class="form-row">
               <label for="node-input-delayToClose"><i class="icon-time"></i> <span data-i18n="opcua-compact-contrib.label.delayToClose"></span></label>
               <input type="text" id="node-input-delayToClose" placeholder="200" style="width:80px">
+          </div>
+          <div class='form-row'> 
+              <label for='node-input-outputs'> Outputs
+              </label> <input type='text' id='node-input-outputs' placeholder='0' style='width:80px'> 
           </div>
           <div class="form-row">
               <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

Please make sure you've read our contributing guidelines (https://github.com/BiancoRoyal/node-red-contrib-opcua-server/blob/develop/.github/CONTRIBUTING.md)

-->

**Which issues are addressed by this Pull Request?**

The outputs option can be used as a trigger in order to monitor for value changes when someone writes a variable value to the OPC UA server just calling the node.send(msg) function in the address space script.
The alternative I thought of is to continuously poll the OPC UA server, get the variable's new value, compare it to the old one and act accordingly. I assume this solution could be a waste of resources and may affect overall performances.

**What does this Pull Request change?**

Added outputs (min 0 and max 10 for the moment...) option in the settings tab of the Compact-Server node.

**Does this Pull Request introduce any potentially breaking changes?**

I don't think so...
<!--
If you have made any changes to the message format sent between nodes or to a node's configuration,
please include bullet points of what changed and what a current user needs to update to keep the same
behavior they have with the previous version.
-->
