### PR TITLE
fix: sandboxed setTimeout/setInterval wrappers never actually applied

### DIFF
--- a/src/core/server-sandbox.js
+++ b/src/core/server-sandbox.js
@@ -62,16 +62,19 @@ module.exports = {
         },
       },
       setTimeout: function () {
-        const func = arguments[0];
-        const timerId = setTimeout.apply(this, arguments);
-        arguments[0] = function () {
+        const args = Array.prototype.slice.call(arguments);
+        const func = args[0];
+        const extraArgs = args.slice(2);
+        let timerId;
+        args[0] = function () {
           sandbox.clearTimeout(timerId);
           try {
-            func.apply(this, arguments);
+            func.apply(this, extraArgs);
           } catch (err) {
             node.error(err, {});
           }
         };
+        timerId = setTimeout.apply(this, args);
         node.outstandingTimers.push(timerId);
         return timerId;
       },
@@ -83,15 +86,17 @@ module.exports = {
         }
       },
       setInterval: function () {
-        const func = arguments[0];
-        const timerId = setInterval.apply(this, arguments);
-        arguments[0] = function () {
+        const args = Array.prototype.slice.call(arguments);
+        const func = args[0];
+        const extraArgs = args.slice(2);
+        args[0] = function () {
           try {
-            func.apply(this, arguments);
+            func.apply(this, extraArgs);
           } catch (err) {
             node.error(err, {});
           }
         };
+        const timerId = setInterval.apply(this, args);
         node.outstandingIntervals.push(timerId);
         return timerId;
       },

--- a/test/core/server-sandbox.test.js
+++ b/test/core/server-sandbox.test.js
@@ -38,4 +38,60 @@ describe("core.server-sandbox unit testing", function () {
       done();
     });
   });
+
+  it("should remove a fired sandboxed setTimeout from node.outstandingTimers", function (done) {
+    const contrib = coreServerSandbox;
+    const EventEmitter = require("events");
+    let node = new EventEmitter();
+    node.error = jest.fn();
+    contrib.initialize(node, {}, (node, vm) => {
+      vm.run("setTimeout(function () {}, 5);");
+      expect(node.outstandingTimers.length).toBe(1);
+      setTimeout(() => {
+        // once the timer has fired, it must be cleaned out of the
+        // tracking array instead of staying there for the life of the node
+        expect(node.outstandingTimers.length).toBe(0);
+        expect(node.error).not.toHaveBeenCalled();
+        done();
+      }, 30);
+    });
+  });
+
+  it("should route an error thrown inside a sandboxed setTimeout to node.error instead of crashing", function (done) {
+    const contrib = coreServerSandbox;
+    const EventEmitter = require("events");
+    let node = new EventEmitter();
+    node.error = jest.fn();
+    contrib.initialize(node, {}, (node, vm) => {
+      vm.run(
+        "setTimeout(function () { throw new Error('boom from script'); }, 5);"
+      );
+      setTimeout(() => {
+        expect(node.error).toHaveBeenCalledTimes(1);
+        expect(node.error.mock.calls[0][0].message).toBe("boom from script");
+        done();
+      }, 30);
+    });
+  });
+
+  it("should route an error thrown inside a sandboxed setInterval to node.error instead of crashing", function (done) {
+    const contrib = coreServerSandbox;
+    const EventEmitter = require("events");
+    let node = new EventEmitter();
+    node.error = jest.fn();
+    contrib.initialize(node, {}, (node, vm) => {
+      vm.run(
+        "setInterval(function () { throw new Error('boom from interval'); }, 5);"
+      );
+      setTimeout(() => {
+        // stop the interval from firing further and re-throwing on the test process
+        node.outstandingIntervals.forEach((id) => clearInterval(id));
+        expect(node.error).toHaveBeenCalled();
+        expect(node.error.mock.calls[0][0].message).toBe(
+          "boom from interval"
+        );
+        done();
+      }, 30);
+    });
+  });
 });


### PR DESCRIPTION
The setTimeout/setInterval overrides exposed to address-space scripts inside the vm2 sandbox built the wrapped callback (which self-clears node.outstandingTimers and catches errors into node.error) AFTER already calling the real setTimeout/setInterval with the original, unwrapped arguments. Reassigning arguments[0] post-hoc had no effect on what was scheduled.

Practical impact:
- setTimeout: the fired timer id was never removed from node.outstandingTimers, so the array grows for the life of the node for any script that uses setTimeout repeatedly.
- setInterval: an error thrown inside a user's interval callback was never caught, becoming an uncaught exception that can crash the Node-RED process instead of being reported via node.error().

Fix: capture the user's function and any extra setTimeout/setInterval arguments before scheduling, and pass the wrapping function itself into the real setTimeout/setInterval call.

Added regression tests in test/core/server-sandbox.test.js that fail against the previous implementation (verified locally by stashing the fix) and pass with it.
